### PR TITLE
Bug Fix: The default ChildTree value was not set correctly.

### DIFF
--- a/spockflow/components/tree/v1/core.py
+++ b/spockflow/components/tree/v1/core.py
@@ -113,6 +113,7 @@ class ChildTree(BaseModel):
                 raise ValueError(
                     f"Cannot set default as length of value ({len_value}) incompatible with tree {len_tree}."
                 )
+        self.default_value = value
 
     def merge_into(self, other: Self):
         len_subtree = len(other)
@@ -123,10 +124,8 @@ class ChildTree(BaseModel):
                     f"Subtree length ({len_subtree}) incompatible with tree ({len_tree})."
                 )
 
-        if other.default_value is not None and self.default_value is not None:
-            raise ValueError(
-                f"Cannot merge two subtrees both containing default values"
-            )
+        if other.default_value is not None:
+            self.set_default(other.default_value)
         self.nodes.extend(other.nodes)
 
 
@@ -332,11 +331,9 @@ class Tree(VariableNode):
         """
         if child_tree is None:
             child_tree = self.root
-        if child_tree.default_value is not None:
-            raise ValueError("Default value already set")
         if isinstance(output, Tree):
             output = output.root
-        child_tree.default_value = output
+        child_tree.set_default(output)
 
     def include_subtree(
         self,

--- a/tests/unit/test_tree.py
+++ b/tests/unit/test_tree.py
@@ -208,7 +208,7 @@ def test_set_default_twice(tree):
         tree.set_default(value(888))  # Default value already set
 
 
-def test_merge_subtrees_with_defaults(tree):
+def test_merge_subtrees_with_only_defaults(tree):
     subtree1 = Tree()
     subtree1.set_default(value(100))
 
@@ -219,6 +219,22 @@ def test_merge_subtrees_with_defaults(tree):
     with pytest.raises(ValueError):
         tree.include_subtree(subtree1)
 
+    with pytest.raises(ValueError):
+        tree.include_subtree(subtree2)
+
+
+def test_merge_subtrees_with_defaults(tree):
+    subtree = Tree()
+    subtree.condition(output=value(100), condition="SubA")
+    subtree.condition(output=value(200), condition="SubB")
+    subtree.set_default(output=value(300))
+
+    subtree2 = Tree()
+    subtree2.condition(output=value(1000), condition="SubD")
+    subtree2.condition(output=value(2000), condition="SubE")
+    subtree2.set_default(output=value(3000))
+
+    tree.include_subtree(subtree)
     with pytest.raises(ValueError):
         tree.include_subtree(subtree2)
 


### PR DESCRIPTION
The default value was set elsewhere instead of in the ChildTree::set_default method. I have updated this and ensured the defaults are handled consistently.

I have also added a test case that fails without these changes.